### PR TITLE
add a toggle to suppress a certain game event for 5 seconds

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -128,6 +128,10 @@
         letter-spacing: 0.5px;
         margin-bottom: 8px;
       }
+      .field label.checkbox-label {
+        margin-bottom: 0;
+        cursor: pointer;
+      }
 
       input,
       select {
@@ -140,6 +144,13 @@
         font-size: 14px;
         font-family: inherit;
         transition: all 0.2s;
+      }
+      input[type="checkbox"] {
+        width: 20px;
+        height: 20px;
+        accent-color: var(--accent);
+        cursor: pointer;
+        padding: 0;
       }
       input:focus,
       select:focus {
@@ -456,6 +467,7 @@
           justify-content: flex-end;
         }
       }
+
     </style>
   </head>
   <body>
@@ -645,6 +657,10 @@
               <div class="field tiny">
                 <label>Value</label>
                 <input type="text" id="newValue" value="" />
+              </div>
+              <div class="field small">
+                <label class="checkbox-label">Suppress</label>
+                <input type="checkbox" id="newSuppress" />
               </div>
               <button class="btn-primary" onclick="addMapping()">Add</button>
             </div>
@@ -1000,6 +1016,10 @@
               <label>Value</label>
               <input type="text" value="${m.condition === '*' ? '' : m.value !== undefined ? m.value : ''}" ${m.condition === '*' ? 'disabled' : ''} onchange="update(${i}, 'value', this.value)">
             </div>
+            <div class="field small">
+              <label class="checkbox-label">Suppress</label>
+              <input type="checkbox" ${m.suppress ? 'checked' : ''} onchange="update(${i}, 'suppress', this.checked)">
+            </div>
           </div>
           <div class="mapping-actions">
             <button class="btn-icon danger" onclick="remove(${i})">✕</button>
@@ -1042,13 +1062,14 @@
         const condition = document.getElementById('newCondition').value;
         const rawValue = document.getElementById('newValue').value;
         const value = condition === '*' ? undefined : parseValue(rawValue);
+        const suppress = document.getElementById('newSuppress').checked;
 
         if (!event || !sound) {
           showMsg('Event and sound are required', 'error');
           return;
         }
 
-        mappings.unshift({ event, sound, condition, value });
+        mappings.unshift({ event, sound, condition, value, suppress });
         render();
 
         const items = document.querySelectorAll('.mapping-item');
@@ -1101,6 +1122,7 @@
         document.getElementById('newSound').value = '';
         document.getElementById('newCondition').value = '===';
         document.getElementById('newValue').value = '';
+        document.getElementById('newSuppress').checked = false;
         updateValueField();
       }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,3 @@
-import { watch } from 'fs';
 import { readdir } from 'fs/promises';
 
 import { Hono } from 'hono';
@@ -79,6 +78,7 @@ const gameSummary = async (matchID: number): Promise<void> => {
 };
 
 let suppressEvents: GameEvent[] = [];
+const suppressedEvents = new Set<string>();
 
 const isSuppressedEvent = (a: GameEvent, b: GameEvent): Boolean => {
   // this will only compare event name and part of the context
@@ -157,6 +157,14 @@ const handleGameEvent = async (event: GameEvent): Promise<void> => {
       }
     }
     if (play) {
+      if (obj.suppress) {
+        if (suppressedEvents.has(event.name)) {
+          logger.info({ event, obj }, 'supressing event')
+          continue;
+        }
+        suppressedEvents.add(event.name);
+        setTimeout(() => suppressedEvents.delete(event.name), 5000);
+      }
       // player.kills and player.kill_streak will always be seen together in the same payload
       // if you get an event for player.kill_streak, suppress the player.kills with the matching context
       // be careful reusing this pattern for other events there is nothing purging stale events in the suppressEvents array
@@ -187,13 +195,6 @@ if (await config.exists()) {
   mapping = [];
 }
 let suppressReport = false;
-
-watch(configFile, async (event) => {
-  if (event === 'change') {
-    mapping = await config.json();
-    logger.info('reload config file!');
-  }
-});
 
 export const app = new Hono();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface MappingEntry {
   sound: string;
   condition: '*' | '>' | '<' | '===' | '!==';
   value: number | string;
+  suppress?: boolean;
 }
 
 export interface GameEvent {


### PR DESCRIPTION
Addresses #14, but defaults to a simple 5 second window so you can map something like the game ending or clock events that every client will report.