### PR TITLE
Add POST /api/sounds/:name/play endpoint; extract playSoundForAll helper

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -100,6 +100,12 @@ const shouldSuppression = (e: GameEvent): Boolean => {
   return false;
 };
 
+const playSoundForAll = (sound: string): void => {
+  for (const conn of Object.values(connections)) {
+    conn.playSound(sound);
+  }
+};
+
 const handleGameEvent = async (event: GameEvent): Promise<void> => {
   // check if this event should be suppressed
   if (shouldSuppression(event)) {
@@ -183,9 +189,7 @@ const handleGameEvent = async (event: GameEvent): Promise<void> => {
         });
       }
       logger.info({ event, obj }, 'triggered mapping');
-      for (const conn of Object.values(connections)) {
-        conn.playSound(obj.sound);
-      }
+      playSoundForAll(obj.sound);
       break;
     }
   }
@@ -236,6 +240,16 @@ app.get('/api/sounds/:name', async (c) => {
       'Content-Disposition': `inline; filename="${name}"`,
     },
   });
+});
+
+app.post('/api/sounds/:name/play', async (c) => {
+  const name = c.req.param('name');
+  const allowed = await getSoundFiles();
+  if (!allowed.includes(name)) {
+    return c.text('Sound not found', 404);
+  }
+  playSoundForAll(name);
+  return c.json({ success: true });
 });
 
 app.post('/api/sounds', async (c) => {


### PR DESCRIPTION
### Summary

Adds a new `POST /api/sounds/:name/play` API endpoint that triggers sound playback on all active Discord voice connections.

### Changes

- **`src/server.ts`** — Extracted the connection playback loop into a `playSoundForAll` helper function
- **`src/server.ts`** — Added `POST /api/sounds/:name/play` endpoint that validates the sound file exists, then calls `playSoundForAll`.
- **`src/server.ts`** — Replaced the inline loop in `handleGameEvent` (previously lines 186–188) with a call to `playSoundForAll`.

This makes the playback feature accessible via HTTP (e.g. from the frontend or external tools) while keeping the event-mapping trigger working identically.