### PR TITLE
add granular otel spans

### DIFF
--- a/src/clickhouse.ts
+++ b/src/clickhouse.ts
@@ -25,8 +25,13 @@ async function flushToClickHouse(): Promise<void> {
     return;
   }
 
-  const dataToInsert = [...eventBuffer];
-  eventBuffer = [];
+  const dataToInsert = tracer.startActiveSpan('clickhouse.event.buffer.snapshot', (snapshotSpan) => {
+    const snapshot = [...eventBuffer];
+    eventBuffer = [];
+    snapshotSpan.setAttribute('buffer.snapshot_size', snapshot.length);
+    snapshotSpan.end();
+    return snapshot;
+  });
 
   return tracer.startActiveSpan('clickhouse.insert.events', async (span) => {
     span.setAttribute('db.system', 'clickhouse');
@@ -35,10 +40,24 @@ async function flushToClickHouse(): Promise<void> {
     span.setAttribute('db.rows_affected', dataToInsert.length);
 
     try {
-      await clickhouseClient.insert({
-        table: 'dota_events',
-        values: dataToInsert,
-        format: 'JSONEachRow',
+      await tracer.startActiveSpan('clickhouse.event.insert', async (insertSpan) => {
+        insertSpan.setAttribute('db.system', 'clickhouse');
+        insertSpan.setAttribute('db.table', 'dota_events');
+        insertSpan.setAttribute('db.rows_affected', dataToInsert.length);
+        try {
+          await clickhouseClient.insert({
+            table: 'dota_events',
+            values: dataToInsert,
+            format: 'JSONEachRow',
+          });
+          insertSpan.setStatus({ code: SpanStatusCode.OK });
+        } catch (error) {
+          insertSpan.setStatus({ code: SpanStatusCode.ERROR });
+          insertSpan.recordException(error as Error);
+          throw error;
+        } finally {
+          insertSpan.end();
+        }
       });
       logger.info(`Successfully flushed ${dataToInsert.length} rows to ClickHouse.`);
       clickhouseRowsFlushed.add(dataToInsert.length, { table: 'dota_events' });
@@ -58,8 +77,13 @@ async function flushRawRequests(): Promise<void> {
     return;
   }
 
-  const dataToInsert = [...rawRequestBuffer];
-  rawRequestBuffer = [];
+  const dataToInsert = tracer.startActiveSpan('clickhouse.raw_request.buffer.snapshot', (snapshotSpan) => {
+    const snapshot = [...rawRequestBuffer];
+    rawRequestBuffer = [];
+    snapshotSpan.setAttribute('buffer.snapshot_size', snapshot.length);
+    snapshotSpan.end();
+    return snapshot;
+  });
 
   return tracer.startActiveSpan('clickhouse.insert.raw_requests', async (span) => {
     span.setAttribute('db.system', 'clickhouse');
@@ -68,10 +92,24 @@ async function flushRawRequests(): Promise<void> {
     span.setAttribute('db.rows_affected', dataToInsert.length);
 
     try {
-      await clickhouseClient.insert({
-        table: 'raw_requests',
-        values: dataToInsert,
-        format: 'JSONEachRow',
+      await tracer.startActiveSpan('clickhouse.raw_request.insert', async (insertSpan) => {
+        insertSpan.setAttribute('db.system', 'clickhouse');
+        insertSpan.setAttribute('db.table', 'raw_requests');
+        insertSpan.setAttribute('db.rows_affected', dataToInsert.length);
+        try {
+          await clickhouseClient.insert({
+            table: 'raw_requests',
+            values: dataToInsert,
+            format: 'JSONEachRow',
+          });
+          insertSpan.setStatus({ code: SpanStatusCode.OK });
+        } catch (error) {
+          insertSpan.setStatus({ code: SpanStatusCode.ERROR });
+          insertSpan.recordException(error as Error);
+          throw error;
+        } finally {
+          insertSpan.end();
+        }
       });
       logger.info(`Flushed ${dataToInsert.length} raw requests to ClickHouse.`);
       clickhouseRowsFlushed.add(dataToInsert.length, { table: 'raw_requests' });
@@ -87,50 +125,81 @@ async function flushRawRequests(): Promise<void> {
 }
 
 export async function logEvent(e: GameEvent): Promise<void> {
-  eventBuffer.push({
-    account_id: e.context.accountID,
-    match_id: e.context.matchID,
-    timestamp: e.context.timestamp,
-    game_time: e.context.gameTime,
-    event_key: e.name,
-    event_value: e.value as number,
-  });
+  return tracer.startActiveSpan('clickhouse.event.buffer', async (span) => {
+    span.setAttribute('event.name', e.name);
+    span.setAttribute('event.key', e.context.accountID);
+    try {
+      eventBuffer.push({
+        account_id: e.context.accountID,
+        match_id: e.context.matchID,
+        timestamp: e.context.timestamp,
+        game_time: e.context.gameTime,
+        event_key: e.name,
+        event_value: e.value as number,
+      });
+      span.setAttribute('buffer.size', eventBuffer.length);
 
-  if (eventBuffer.length >= BATCH_SIZE_THRESHOLD) {
-    await flushToClickHouse();
-  }
+      if (eventBuffer.length >= BATCH_SIZE_THRESHOLD) {
+        span.setAttribute('buffer.flush_triggered', true);
+        await flushToClickHouse();
+      } else {
+        span.setAttribute('buffer.flush_triggered', false);
+      }
+    } finally {
+      span.end();
+    }
+  });
 }
 
 export async function logRawRequest(payload: { previously?: Record<string, unknown> }): Promise<void> {
-  const requestKeys = new Set(getDeepKeys(payload.previously));
-  const ignoreSet = new Set([
-    'map',
-    'map.game_time',
-    'map.clock_time',
-    'player',
-    'player.gold',
-    'player.gold_reliable',
-    'player.gold_unreliable',
-    'player.gold_from_income',
-    'player.gpm',
-    'player.xpm',
-    'hero',
-    'hero.health',
-    'hero.mana',
-    'hero.mana_percent',
-    'items',
-    'items.teleport0',
-    'items.teleport0.cooldown',
-  ]);
-  if (requestKeys.difference(ignoreSet).size === 0) {
-    return;
-  }
+  return tracer.startActiveSpan('clickhouse.raw_request.buffer', async (span) => {
+    try {
+      const requestKeys = tracer.startActiveSpan('clickhouse.raw_request.keys', (keysSpan) => {
+        const keys = new Set(getDeepKeys(payload.previously));
+        keysSpan.setAttribute('keys.count', keys.size);
+        keysSpan.end();
+        return keys;
+      });
 
-  rawRequestBuffer.push({ timestamp: Date.now(), payload });
+      const ignoreSet = new Set([
+        'map',
+        'map.game_time',
+        'map.clock_time',
+        'player',
+        'player.gold',
+        'player.gold_reliable',
+        'player.gold_unreliable',
+        'player.gold_from_income',
+        'player.gpm',
+        'player.xpm',
+        'hero',
+        'hero.health',
+        'hero.mana',
+        'hero.mana_percent',
+        'items',
+        'items.teleport0',
+        'items.teleport0.cooldown',
+      ]);
+      if (requestKeys.difference(ignoreSet).size === 0) {
+        span.setAttribute('request.filtered', true);
+        return;
+      }
+      span.setAttribute('request.filtered', false);
+      span.setAttribute('request.keys_count', requestKeys.size);
 
-  if (rawRequestBuffer.length >= BATCH_SIZE_THRESHOLD) {
-    await flushRawRequests();
-  }
+      rawRequestBuffer.push({ timestamp: Date.now(), payload });
+      span.setAttribute('buffer.size', rawRequestBuffer.length);
+
+      if (rawRequestBuffer.length >= BATCH_SIZE_THRESHOLD) {
+        span.setAttribute('buffer.flush_triggered', true);
+        await flushRawRequests();
+      } else {
+        span.setAttribute('buffer.flush_triggered', false);
+      }
+    } finally {
+      span.end();
+    }
+  });
 }
 
 function getDeepKeys(obj: unknown, prefix = ''): string[] {
@@ -151,7 +220,13 @@ function getDeepKeys(obj: unknown, prefix = ''): string[] {
 }
 
 export function startClickHouse(): void {
-  logger.info('ClickHouse client initialized');
-  setInterval(flushToClickHouse, FLUSH_INTERVAL_MS);
-  setInterval(flushRawRequests, FLUSH_INTERVAL_MS);
+  tracer.startActiveSpan('clickhouse.init', (span) => {
+    span.setAttribute('db.system', 'clickhouse');
+    span.setAttribute('clickhouse.batch_size', BATCH_SIZE_THRESHOLD);
+    span.setAttribute('clickhouse.flush_interval_ms', FLUSH_INTERVAL_MS);
+    logger.info('ClickHouse client initialized');
+    setInterval(flushToClickHouse, FLUSH_INTERVAL_MS);
+    setInterval(flushRawRequests, FLUSH_INTERVAL_MS);
+    span.end();
+  });
 }

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -61,15 +61,20 @@ export class VoiceConnection {
         logger.info(`voice connection opened @${this.guild.name} -> ${this.channel.name}`);
         span.addEvent('voice.connected');
         discordVoiceConnections.add(1);
+        span.end();
       });
 
       this.connection.on(VoiceConnectionStatus.Disconnected, () => {
         logger.info(`voice connection closed @${this.guild.name} -> ${this.channel.name}`);
-        span.addEvent('voice.disconnected');
-        discordVoiceConnections.add(-1);
+        tracer.startActiveSpan('discord.voice.disconnect', (disconnectSpan) => {
+          disconnectSpan.setAttribute('guild.id', guildId);
+          disconnectSpan.setAttribute('guild.name', this.guild.name);
+          disconnectSpan.setAttribute('channel.id', channelId);
+          disconnectSpan.setAttribute('channel.name', this.channel.name);
+          discordVoiceConnections.add(-1);
+          disconnectSpan.end();
+        });
       });
-
-      span.end();
     });
   }
 
@@ -79,14 +84,46 @@ export class VoiceConnection {
       span.setAttribute('guild.name', this.guild.name);
       span.setAttribute('channel.name', this.channel.name);
 
-      logger.info(`playing sound ${fileName} @${this.guild.name} -> ${this.channel.name}`);
-      if (!this.subscription) {
-        this.subscription = this.connection.subscribe(this.player);
-      }
-      const resource = createAudioResource(SOUNDS_DIR + fileName);
-      this.player.play(resource);
+      try {
+        logger.info(`playing sound ${fileName} @${this.guild.name} -> ${this.channel.name}`);
+        if (!this.subscription) {
+          tracer.startActiveSpan('discord.voice.subscribe', (subscribeSpan) => {
+            subscribeSpan.setAttribute('guild.name', this.guild.name);
+            try {
+              this.subscription = this.connection.subscribe(this.player);
+            } catch (error) {
+              subscribeSpan.setStatus({ code: SpanStatusCode.ERROR });
+              subscribeSpan.recordException(error as Error);
+              throw error;
+            } finally {
+              subscribeSpan.end();
+            }
+          });
+        }
 
-      span.end();
+        const resource = tracer.startActiveSpan('discord.voice.resource.create', (resourceSpan) => {
+          resourceSpan.setAttribute('sound.file', fileName);
+          resourceSpan.setAttribute('resource.path', SOUNDS_DIR + fileName);
+          try {
+            const res = createAudioResource(SOUNDS_DIR + fileName);
+            return res;
+          } catch (error) {
+            resourceSpan.setStatus({ code: SpanStatusCode.ERROR });
+            resourceSpan.recordException(error as Error);
+            throw error;
+          } finally {
+            resourceSpan.end();
+          }
+        });
+
+        this.player.play(resource);
+      } catch (error) {
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        span.recordException(error as Error);
+        throw error;
+      } finally {
+        span.end();
+      }
     });
   }
 }
@@ -102,22 +139,36 @@ export const client = new Client({
 
 client.commands = new Collection();
 
-const foldersPath = path.join(import.meta.dir, '..', 'commands');
-const commandFolders = fs.readdirSync(foldersPath);
+tracer.startActiveSpan('discord.commands.load', async (span) => {
+  const loadedCommands: string[] = [];
+  try {
+    const foldersPath = path.join(import.meta.dir, '..', 'commands');
+    const commandFolders = fs.readdirSync(foldersPath);
 
-for (const folder of commandFolders) {
-  const commandsPath = path.join(foldersPath, folder);
-  const commandFiles = fs.readdirSync(commandsPath).filter((file) => file.endsWith('.ts'));
-  for (const file of commandFiles) {
-    const filePath = path.join(commandsPath, file);
-    const command = (await import(filePath)) as Command;
-    if ('data' in command && 'execute' in command) {
-      client.commands.set(command.data.name, command);
-    } else {
-      logger.warn(`The command at ${filePath} is missing a required "data" or "execute" property.`);
+    for (const folder of commandFolders) {
+      const commandsPath = path.join(foldersPath, folder);
+      const commandFiles = fs.readdirSync(commandsPath).filter((file) => file.endsWith('.ts'));
+      for (const file of commandFiles) {
+        const filePath = path.join(commandsPath, file);
+        const command = (await import(filePath)) as Command;
+        if ('data' in command && 'execute' in command) {
+          client.commands.set(command.data.name, command);
+          loadedCommands.push(command.data.name);
+        } else {
+          logger.warn(`The command at ${filePath} is missing a required "data" or "execute" property.`);
+        }
+      }
     }
+    span.setAttribute('commands.count', loadedCommands.length);
+    span.setAttribute('commands.names', loadedCommands.join(','));
+  } catch (error) {
+    span.setStatus({ code: SpanStatusCode.ERROR });
+    span.recordException(error as Error);
+    throw error;
+  } finally {
+    span.end();
   }
-}
+});
 
 client.on(Events.InteractionCreate, async (interaction) => {
   if (!interaction.isChatInputCommand()) {
@@ -161,25 +212,66 @@ client.on(Events.InteractionCreate, async (interaction) => {
 });
 
 client.once(Events.ClientReady, () => {
-  logger.info(`bot logged in as ${client.user?.tag}`);
+  tracer.startActiveSpan('discord.ready', (span) => {
+    span.setAttribute('user.tag', client.user?.tag ?? 'unknown');
+    span.setAttribute('user.id', client.user?.id ?? 'unknown');
+    logger.info(`bot logged in as ${client.user?.tag}`);
+    span.end();
+  });
 });
 
 client.on(Events.VoiceStateUpdate, (oldState, newState) => {
   if (!oldState.channelId && newState.channelId && newState.member?.user.id !== client.user?.id) {
-    logger.info(`${newState.member?.user.tag} joined ${newState.channel?.name}`);
+    const joinChannelId = newState.channelId;
+    tracer.startActiveSpan('discord.voice_state.join', (span) => {
+      span.setAttribute('user.id', newState.member?.user.id ?? 'unknown');
+      span.setAttribute('user.tag', newState.member?.user.tag ?? 'unknown');
+      span.setAttribute('channel.id', joinChannelId);
+      span.setAttribute('channel.name', newState.channel?.name ?? 'unknown');
+      span.setAttribute('guild.id', newState.guild.id);
+      try {
+        logger.info(`${newState.member?.user.tag} joined ${newState.channel?.name}`);
 
-    if (!connections[newState.channelId]) {
-      connections[newState.channelId] = new VoiceConnection(newState.guild.id, newState.channelId, client);
-    }
-    connections[newState.channelId]!.playSound('open-aim.mp3');
+        if (!connections[joinChannelId]) {
+          connections[joinChannelId] = new VoiceConnection(newState.guild.id, joinChannelId, client);
+        }
+        connections[joinChannelId]!.playSound('open-aim.mp3');
+      } finally {
+        span.end();
+      }
+    });
   }
 
   if (oldState.channelId && !newState.channelId) {
-    logger.info(`${oldState.member?.user.tag} left ${oldState.channel?.name}`);
-    if (oldState.channel?.members.size === 1 && connections[oldState.channelId]) {
-      connections[oldState.channelId]!.connection.destroy();
-      delete connections[oldState.channelId];
-    }
+    const leaveChannelId = oldState.channelId;
+    tracer.startActiveSpan('discord.voice_state.leave', (span) => {
+      span.setAttribute('user.id', oldState.member?.user.id ?? 'unknown');
+      span.setAttribute('user.tag', oldState.member?.user.tag ?? 'unknown');
+      span.setAttribute('channel.id', leaveChannelId);
+      span.setAttribute('channel.name', oldState.channel?.name ?? 'unknown');
+      span.setAttribute('guild.id', oldState.guild.id);
+      try {
+        logger.info(`${oldState.member?.user.tag} left ${oldState.channel?.name}`);
+        if (oldState.channel?.members.size === 1 && connections[leaveChannelId]) {
+          tracer.startActiveSpan('discord.voice.destroy', (destroySpan) => {
+            destroySpan.setAttribute('channel.id', leaveChannelId);
+            destroySpan.setAttribute('guild.id', oldState.guild.id);
+            try {
+              connections[leaveChannelId]!.connection.destroy();
+              delete connections[leaveChannelId];
+            } catch (error) {
+              destroySpan.setStatus({ code: SpanStatusCode.ERROR });
+              destroySpan.recordException(error as Error);
+              throw error;
+            } finally {
+              destroySpan.end();
+            }
+          });
+        }
+      } finally {
+        span.end();
+      }
+    });
   }
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,26 +29,34 @@ const recursiveDiff = (
   body: Record<string, unknown>,
   context: GameEventContext,
 ): void => {
-  for (const key of Object.keys(changed)) {
-    if (typeof changed[key] === 'object' && changed[key] !== null) {
-      if (body[key] != null) {
-        recursiveDiff(
-          `${prefix}${key}.`,
-          changed[key] as Record<string, unknown>,
-          body[key] as Record<string, unknown>,
-          context,
-        );
+  tracer.startActiveSpan('game.event.diff', (span) => {
+    span.setAttribute('diff.prefix', prefix);
+    span.setAttribute('diff.keys_count', Object.keys(changed).length);
+    try {
+      for (const key of Object.keys(changed)) {
+        if (typeof changed[key] === 'object' && changed[key] !== null) {
+          if (body[key] != null) {
+            recursiveDiff(
+              `${prefix}${key}.`,
+              changed[key] as Record<string, unknown>,
+              body[key] as Record<string, unknown>,
+              context,
+            );
+          }
+        } else {
+          if (body[key] != null) {
+            handleGameEvent({
+              name: `${prefix}${key}`,
+              value: body[key] as string | number,
+              context: context,
+            });
+          }
+        }
       }
-    } else {
-      if (body[key] != null) {
-        handleGameEvent({
-          name: `${prefix}${key}`,
-          value: body[key] as string | number,
-          context: context,
-        });
-      }
+    } finally {
+      span.end();
     }
-  }
+  });
 };
 
 const gameSummary = async (matchID: number): Promise<void> => {
@@ -61,19 +69,47 @@ const gameSummary = async (matchID: number): Promise<void> => {
   if (await f.exists()) {
     const settings = (await f.json()) as Settings;
     if (settings.channel) {
+      const channelId = settings.channel;
       const { client } = await import('./discord.js');
-      const channel = await client.channels.fetch(settings.channel);
-      if (channel?.isSendable()) {
-        channel.send(`https://www.opendota.com/matches/${matchID}`);
-        logger.info(`sent match details to channel ${settings.channel}`);
-      }
+      await tracer.startActiveSpan('game.summary.discord.send', async (discordSpan) => {
+        discordSpan.setAttribute('channel.id', channelId);
+        discordSpan.setAttribute('match_id', matchID);
+        try {
+          const channel = await client.channels.fetch(channelId);
+          if (channel?.isSendable()) {
+            await channel.send(`https://www.opendota.com/matches/${matchID}`);
+            logger.info(`sent match details to channel ${channelId}`);
+          }
+        } catch (error) {
+          discordSpan.setStatus({ code: SpanStatusCode.ERROR });
+          discordSpan.recordException(error as Error);
+          throw error;
+        } finally {
+          discordSpan.end();
+        }
+      });
 
       setTimeout(async () => {
         suppressReport = false;
-        const response = await fetch(`http://api.opendota.com/api/request/${matchID}`, {
-          method: 'POST',
+        await tracer.startActiveSpan('game.summary.opendota.request', async (opendotaSpan) => {
+          opendotaSpan.setAttribute('match_id', matchID);
+          try {
+            const response = await fetch(`http://api.opendota.com/api/request/${matchID}`, {
+              method: 'POST',
+            });
+            opendotaSpan.setAttribute('http.status_code', response.status);
+            if (response.status >= 400) {
+              opendotaSpan.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${response.status}` });
+            }
+            logger.info(`opendota parse request for matchID=${matchID} http_status=${response.status}`);
+          } catch (error) {
+            opendotaSpan.setStatus({ code: SpanStatusCode.ERROR });
+            opendotaSpan.recordException(error as Error);
+            throw error;
+          } finally {
+            opendotaSpan.end();
+          }
         });
-        logger.info(`opendota parse request for matchID=${matchID} http_status=${response.status}`);
       }, 5000);
     }
   }
@@ -102,10 +138,18 @@ const shouldSuppression = (e: GameEvent): boolean => {
 };
 
 const playSoundForAll = (sound: string): void => {
-  for (const conn of Object.values(connections)) {
-    conn.playSound(sound);
-    soundsPlayedTotal.add(1, { sound });
-  }
+  tracer.startActiveSpan('sound.broadcast', (span) => {
+    span.setAttribute('sound.name', sound);
+    span.setAttribute('connections.count', Object.keys(connections).length);
+    try {
+      for (const conn of Object.values(connections)) {
+        conn.playSound(sound);
+        soundsPlayedTotal.add(1, { sound });
+      }
+    } finally {
+      span.end();
+    }
+  });
 };
 
 const handleGameEvent = async (event: GameEvent): Promise<void> =>
@@ -119,7 +163,13 @@ const handleGameEvent = async (event: GameEvent): Promise<void> =>
 
     try {
       // check if this event should be suppressed
-      if (shouldSuppression(event)) {
+      const suppressed = tracer.startActiveSpan('game.event.suppress.check', (suppressSpan) => {
+        const result = shouldSuppression(event);
+        suppressSpan.setAttribute('suppressed', result);
+        suppressSpan.end();
+        return result;
+      });
+      if (suppressed) {
         logger.info({ event }, 'suppressing event');
         span.addEvent('event.suppressed');
         return;
@@ -128,84 +178,112 @@ const handleGameEvent = async (event: GameEvent): Promise<void> =>
       logger.debug({ event }, 'handling event');
 
       if (!(event.name === 'map.game_time' || event.name === 'map.clock_time') && typeof event.value === 'number') {
-        logEvent(event);
+        tracer.startActiveSpan('game.event.log', (logSpan) => {
+          logSpan.setAttribute('event.name', event.name);
+          logEvent(event);
+          logSpan.end();
+        });
       }
 
       if (event.name === 'map.game_state' && event.value === 'DOTA_GAMERULES_STATE_POST_GAME' && !suppressReport) {
-        gameSummary(event.context.matchID);
+        tracer.startActiveSpan('game.event.summary', (summarySpan) => {
+          summarySpan.setAttribute('match_id', event.context.matchID);
+          gameSummary(event.context.matchID);
+          summarySpan.end();
+        });
         // lazy - cleanup any leftovers in suppressEvents at match end
         suppressEvents = [];
       }
 
-      for (const obj of mapping) {
-        if (obj.event !== event.name) {
-          continue;
-        }
-
-        let play = false;
-        switch (obj.condition) {
-          case '*': {
-            play = true;
-            break;
-          }
-          case '>': {
-            if (event.value > obj.value) {
-              play = true;
-            }
-            break;
-          }
-          case '<': {
-            if (event.value < obj.value) {
-              play = true;
-            }
-            break;
-          }
-          case '===': {
-            if (event.value === obj.value) {
-              play = true;
-            }
-            break;
-          }
-          case '!==': {
-            if (event.value !== obj.value) {
-              play = true;
-            }
-            break;
-          }
-          case '%': {
-            if (typeof event.value === 'number' && typeof obj.value === 'number') {
-              if (event.value % obj.value === 0) {
-                play = true;
-              }
-            }
-            break;
-          }
-        }
-        if (play) {
-          if (obj.suppress) {
-            if (suppressedEvents.has(event.name)) {
-              logger.info({ event, obj }, 'supressing event');
+      let matchedIndex = -1;
+      tracer.startActiveSpan('game.event.mapping.evaluate', (mappingSpan) => {
+        mappingSpan.setAttribute('mapping.entries_count', mapping.length);
+        mappingSpan.setAttribute('event.name', event.name);
+        try {
+          for (const [idx, obj] of mapping.entries()) {
+            if (obj.event !== event.name) {
               continue;
             }
-            suppressedEvents.add(event.name);
-            setTimeout(() => suppressedEvents.delete(event.name), 5000);
+
+            let play = false;
+            switch (obj.condition) {
+              case '*': {
+                play = true;
+                break;
+              }
+              case '>': {
+                if (event.value > obj.value) {
+                  play = true;
+                }
+                break;
+              }
+              case '<': {
+                if (event.value < obj.value) {
+                  play = true;
+                }
+                break;
+              }
+              case '===': {
+                if (event.value === obj.value) {
+                  play = true;
+                }
+                break;
+              }
+              case '!==': {
+                if (event.value !== obj.value) {
+                  play = true;
+                }
+                break;
+              }
+              case '%': {
+                if (typeof event.value === 'number' && typeof obj.value === 'number') {
+                  if (event.value % obj.value === 0) {
+                    play = true;
+                  }
+                }
+                break;
+              }
+            }
+            if (play) {
+              if (obj.suppress) {
+                if (suppressedEvents.has(event.name)) {
+                  logger.info({ event, obj }, 'supressing event');
+                  continue;
+                }
+                suppressedEvents.add(event.name);
+                setTimeout(() => suppressedEvents.delete(event.name), 5000);
+              }
+              // player.kills and player.kill_streak will always be seen together in the same payload
+              // if you get an event for player.kill_streak, suppress the player.kills with the matching context
+              // be careful reusing this pattern for other events there is nothing purging stale events in the suppressEvents array
+              if (event.name === 'player.kill_streak') {
+                suppressEvents.push({
+                  name: 'player.kills',
+                  value: 0, //value is required for the GameEvent type at the moment but not checked in the suppression logic
+                  context: event.context,
+                });
+              }
+              logger.info({ event, obj }, 'triggered mapping');
+              matchedIndex = idx;
+              span.addEvent('sound.triggered', { sound: obj.sound });
+              tracer.startActiveSpan('game.event.sound.play', (soundSpan) => {
+                soundSpan.setAttribute('sound.name', obj.sound);
+                soundSpan.setAttribute('connections.count', Object.keys(connections).length);
+                try {
+                  playSoundForAll(obj.sound);
+                } finally {
+                  soundSpan.end();
+                }
+              });
+              break;
+            }
           }
-          // player.kills and player.kill_streak will always be seen together in the same payload
-          // if you get an event for player.kill_streak, suppress the player.kills with the matching context
-          // be careful reusing this pattern for other events there is nothing purging stale events in the suppressEvents array
-          if (event.name === 'player.kill_streak') {
-            suppressEvents.push({
-              name: 'player.kills',
-              value: 0, //value is required for the GameEvent type at the moment but not checked in the suppression logic
-              context: event.context,
-            });
-          }
-          logger.info({ event, obj }, 'triggered mapping');
-          span.addEvent('sound.triggered', { sound: obj.sound });
-          playSoundForAll(obj.sound);
-          break;
+        } finally {
+          mappingSpan.setAttribute('mapping.matched', matchedIndex >= 0);
+          mappingSpan.setAttribute('mapping.matched_index', matchedIndex);
+          mappingSpan.end();
         }
-      }
+      });
     } catch (error) {
       span.setStatus({ code: SpanStatusCode.ERROR });
       span.recordException(error as Error);
@@ -257,80 +335,168 @@ app.use('*', async (c, next) => {
   });
 });
 
-app.get('/api/mappings', async (c) => {
-  const f = Bun.file('mapping.json');
-  const data = await f.json();
-  return c.json(data);
-});
+app.get('/api/mappings', async (c) =>
+  tracer.startActiveSpan('api.mappings.read', async (span) => {
+    try {
+      const f = Bun.file('mapping.json');
+      const data = await f.json();
+      span.setAttribute('file', 'mapping.json');
+      return c.json(data);
+    } catch (error) {
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      span.recordException(error as Error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  }),
+);
 
-app.put('/api/mappings', async (c) => {
-  const data = (await c.req.json()) as MappingEntry[];
-  await Bun.write('mapping.json', JSON.stringify(data, null, 2));
-  mapping = data;
-  return c.json({ success: true });
-});
+app.put('/api/mappings', async (c) =>
+  tracer.startActiveSpan('api.mappings.write', async (span) => {
+    try {
+      const data = (await c.req.json()) as MappingEntry[];
+      await Bun.write('mapping.json', JSON.stringify(data, null, 2));
+      mapping = data;
+      span.setAttribute('mappings.count', data.length);
+      return c.json({ success: true });
+    } catch (error) {
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      span.recordException(error as Error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  }),
+);
 
-app.get('/api/sounds', async (c) => {
-  const sounds = await getSoundFiles();
-  return c.json(sounds);
-});
+app.get('/api/sounds', async (c) =>
+  tracer.startActiveSpan('api.sounds.list', async (span) => {
+    try {
+      const sounds = await getSoundFiles();
+      span.setAttribute('sounds.count', sounds.length);
+      return c.json(sounds);
+    } catch (error) {
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      span.recordException(error as Error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  }),
+);
 
-app.get('/api/sounds/:name', async (c) => {
-  const name = c.req.param('name');
-  const allowed = await getSoundFiles();
-  if (!allowed.includes(name)) {
-    return c.text('Not found', 404);
-  }
-  const file = Bun.file(SOUNDS_DIR + name);
-  return c.body(file.stream(), {
-    headers: {
-      'Content-Type': 'audio/mpeg',
-      'Content-Disposition': `inline; filename="${name}"`,
-    },
-  });
-});
+app.get('/api/sounds/:name', async (c) =>
+  tracer.startActiveSpan('api.sound.serve', async (span) => {
+    const name = c.req.param('name');
+    span.setAttribute('sound.name', name);
+    try {
+      const allowed = await getSoundFiles();
+      if (!allowed.includes(name)) {
+        span.setAttribute('sound.found', false);
+        return c.text('Not found', 404);
+      }
+      span.setAttribute('sound.found', true);
+      const file = Bun.file(SOUNDS_DIR + name);
+      return c.body(file.stream(), {
+        headers: {
+          'Content-Type': 'audio/mpeg',
+          'Content-Disposition': `inline; filename="${name}"`,
+        },
+      });
+    } catch (error) {
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      span.recordException(error as Error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  }),
+);
 
-app.post('/api/sounds/:name/play', async (c) => {
-  const name = c.req.param('name');
-  const allowed = await getSoundFiles();
-  if (!allowed.includes(name)) {
-    return c.text('Sound not found', 404);
-  }
-  playSoundForAll(name);
-  return c.json({ success: true });
-});
+app.post('/api/sounds/:name/play', async (c) =>
+  tracer.startActiveSpan('api.sound.play', async (span) => {
+    const name = c.req.param('name');
+    span.setAttribute('sound.name', name);
+    try {
+      const allowed = await getSoundFiles();
+      if (!allowed.includes(name)) {
+        span.setAttribute('sound.found', false);
+        return c.text('Sound not found', 404);
+      }
+      span.setAttribute('sound.found', true);
+      playSoundForAll(name);
+      return c.json({ success: true });
+    } catch (error) {
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      span.recordException(error as Error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  }),
+);
 
-app.post('/api/sounds', async (c) => {
-  const formData = await c.req.formData();
-  const file = formData.get('file') as File | null;
-  if (!file || !(file instanceof File)) {
-    return c.text('No file provided', 400);
-  }
-  if (!file.name.toLowerCase().endsWith('.mp3')) {
-    return c.text('Only MP3 files allowed', 400);
-  }
-  if (file.size > MAX_FILE_SIZE) {
-    return c.text('File too large (max 10MB)', 400);
-  }
-  const name = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
-  if (name.startsWith('.')) {
-    return c.text('Hidden files not allowed', 400);
-  }
-  const dest = Bun.file(SOUNDS_DIR + name);
-  await Bun.write(dest, file);
-  return c.json({ success: true, name });
-});
+app.post('/api/sounds', async (c) =>
+  tracer.startActiveSpan('api.sound.upload', async (span) => {
+    try {
+      const formData = await c.req.formData();
+      const file = formData.get('file') as File | null;
+      if (!file || !(file instanceof File)) {
+        span.setAttribute('upload.rejected', 'no_file');
+        return c.text('No file provided', 400);
+      }
+      if (!file.name.toLowerCase().endsWith('.mp3')) {
+        span.setAttribute('upload.rejected', 'invalid_type');
+        return c.text('Only MP3 files allowed', 400);
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        span.setAttribute('upload.rejected', 'too_large');
+        return c.text('File too large (max 10MB)', 400);
+      }
+      const name = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+      if (name.startsWith('.')) {
+        span.setAttribute('upload.rejected', 'hidden_file');
+        return c.text('Hidden files not allowed', 400);
+      }
+      span.setAttribute('sound.name', name);
+      span.setAttribute('file.size', file.size);
+      const dest = Bun.file(SOUNDS_DIR + name);
+      await Bun.write(dest, file);
+      return c.json({ success: true, name });
+    } catch (error) {
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      span.recordException(error as Error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  }),
+);
 
-app.delete('/api/sounds/:name', async (c) => {
-  const name = c.req.param('name');
-  const allowed = await getSoundFiles();
-  if (!allowed.includes(name)) {
-    return c.text('Not found', 404);
-  }
-  const file = Bun.file(SOUNDS_DIR + name);
-  await file.delete();
-  return c.json({ success: true });
-});
+app.delete('/api/sounds/:name', async (c) =>
+  tracer.startActiveSpan('api.sound.delete', async (span) => {
+    const name = c.req.param('name');
+    span.setAttribute('sound.name', name);
+    try {
+      const allowed = await getSoundFiles();
+      if (!allowed.includes(name)) {
+        span.setAttribute('sound.found', false);
+        return c.text('Not found', 404);
+      }
+      span.setAttribute('sound.found', true);
+      const file = Bun.file(SOUNDS_DIR + name);
+      await file.delete();
+      return c.json({ success: true });
+    } catch (error) {
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      span.recordException(error as Error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  }),
+);
 
 app.get('/', async (c) => {
   const file = Bun.file('./public/index.html');
@@ -340,15 +506,37 @@ app.get('/', async (c) => {
 app.post('/', async (c) => {
   const payload = await c.req.json();
   if (payload.previously) {
-    const ctx: GameEventContext = {
-      accountID: payload.player.accountid,
-      matchID: payload.map.matchid,
-      gameTime: payload.map.game_time,
-      timestamp: payload.provider.timestamp * 1000,
-    };
-    recursiveDiff('', payload.previously, payload, ctx);
+    const ctx: GameEventContext = await tracer.startActiveSpan('webhook.payload.parse', (span) => {
+      const context: GameEventContext = {
+        accountID: payload.player.accountid,
+        matchID: payload.map.matchid,
+        gameTime: payload.map.game_time,
+        timestamp: payload.provider.timestamp * 1000,
+      };
+      span.setAttribute('account_id', context.accountID);
+      span.setAttribute('match_id', context.matchID);
+      span.setAttribute('game_time', context.gameTime);
+      span.setAttribute('diff.keys_count', Object.keys(payload.previously).length);
+      span.end();
+      return context;
+    });
 
-    await logRawRequest(payload);
+    tracer.startActiveSpan('webhook.diff.process', (diffSpan) => {
+      diffSpan.setAttribute('diff.top_level_keys', Object.keys(payload.previously).length);
+      try {
+        recursiveDiff('', payload.previously, payload, ctx);
+      } finally {
+        diffSpan.end();
+      }
+    });
+
+    tracer.startActiveSpan('webhook.request.log', async (logSpan) => {
+      try {
+        await logRawRequest(payload);
+      } finally {
+        logSpan.end();
+      }
+    });
   }
   return c.text('OK', 200);
 });


### PR DESCRIPTION
## Summary

Adds granular OpenTelemetry spans across `server.ts`, `discord.ts`, and `clickhouse.ts` for better observability into game event processing, Discord voice/command lifecycle, and ClickHouse buffer/insert operations.

### server.ts (18 new spans)
- **Webhook pipeline**: `webhook.payload.parse`, `webhook.diff.process`, `webhook.request.log`
- **Game event processing**: `game.event.diff`, `game.event.suppress.check`, `game.event.log`, `game.event.summary`, `game.event.mapping.evaluate`, `game.event.sound.play`
- **External calls**: `game.summary.discord.send`, `game.summary.opendota.request`
- **Sound broadcast**: `sound.broadcast`
- **API endpoints**: `api.mappings.read`, `api.mappings.write`, `api.sounds.list`, `api.sound.serve`, `api.sound.play`, `api.sound.upload`, `api.sound.delete`

### discord.ts (8 new spans + fixes)
- **Command lifecycle**: `discord.commands.load`
- **Voice connection**: `discord.voice.disconnect`, `discord.voice.subscribe`, `discord.voice.resource.create`
- **Bot events**: `discord.ready`, `discord.voice_state.join`, `discord.voice_state.leave`, `discord.voice.destroy`
- **Fix**: `discord.voice.connect` span now ends in `Ready` handler instead of synchronously in constructor
- **Fix**: `discord.voice.play` now has try/catch error handling with `SpanStatusCode.ERROR`

### clickhouse.ts (8 new spans)
- **Buffer operations**: `clickhouse.event.buffer`, `clickhouse.event.buffer.snapshot`, `clickhouse.raw_request.buffer`, `clickhouse.raw_request.buffer.snapshot`
- **Key extraction**: `clickhouse.raw_request.keys`
- **Network I/O**: `clickhouse.event.insert`, `clickhouse.raw_request.insert`
- **Initialization**: `clickhouse.init`