### PR TITLE
Restructure mapping config and restyle UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,24 +110,28 @@ ENABLE_DISCORD=false bun run dev
 
 ### Event-to-Sound Mappings (`mapping.json`)
 
-On first run, the app automatically creates `mapping.json` with an empty array `[]`. Edit via the Web UI at `http://localhost:3000/` or directly edit the file.
+On first run, the app automatically creates `mapping.json` with `{ "dota": {} }`. Edit via the Web UI at `http://localhost:3000/` or directly edit the file.
 
 Sample `mapping.json`:
 ```json
-[
-  {
-    "event": "player.deaths",
-    "sound": "fail.mp3",
-    "condition": ">",
-    "value": 0
-  },
-  {
-    "event": "player.kills",
-    "sound": "kill.mp3",
-    "condition": "===",
-    "value": 10
+{
+  "dota": {
+    "player.deaths": [
+      {
+        "sound": "fail.mp3",
+        "condition": ">",
+        "value": 0
+      }
+    ],
+    "player.kills": [
+      {
+        "sound": "kill.mp3",
+        "condition": "===",
+        "value": 10
+      }
+    ]
   }
-]
+}
 ```
 
 **Supported Conditions:**

--- a/public/index.html
+++ b/public/index.html
@@ -83,6 +83,13 @@
         align-items: center;
         margin-bottom: 24px;
       }
+      .mappings-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 16px;
+        margin-top: 24px;
+      }
       h3 {
         font-size: 13px;
         font-weight: 600;
@@ -204,14 +211,6 @@
         box-shadow: 0 6px 24px rgba(88, 166, 255, 0.4);
       }
 
-      .mapping-item {
-        background: var(--input-bg);
-        border: 1px solid var(--border);
-        border-radius: 12px;
-        padding: 20px;
-        margin-bottom: 16px;
-        transition: all 0.25s ease;
-      }
       .mapping-item:hover {
         border-color: rgba(88, 166, 255, 0.4);
       }
@@ -232,10 +231,10 @@
         margin-bottom: 0;
       }
       .mapping-item .field:first-child {
-        flex: 0 0 180px;
+        flex: 2;
       }
       .mapping-item .field:nth-child(2) {
-        flex: 2;
+        flex: 0 0 90px;
       }
 
       .mapping-actions {
@@ -308,6 +307,39 @@
         margin-bottom: 16px;
         transition: all 0.25s ease;
         gap: 10px;
+      }
+
+      .event-group {
+        margin-bottom: 24px;
+      }
+      .event-group-header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 12px 16px;
+        background: var(--card-bg);
+        border: 1px solid var(--border);
+        border-radius: 12px 12px 0 0;
+      }
+      .event-name {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--accent);
+        font-family: 'SF Mono', 'Fira Code', monospace;
+      }
+      .event-count {
+        font-size: 12px;
+        color: var(--text-muted);
+        background: var(--input-bg);
+        padding: 2px 8px;
+        border-radius: 6px;
+      }
+      .event-group-body {
+        border: 1px solid var(--border);
+        border-top: none;
+        border-radius: 0 0 12px 12px;
+        padding: 12px;
+        background: var(--card-bg);
       }
 
       .empty {
@@ -507,134 +539,20 @@
               <div class="field">
                 <label>Event Name</label>
                 <select id="newEvent">
-                  <optgroup label="Map">
-                    <option value="map.name">map.name</option>
-                    <option value="map.matchid">map.matchid</option>
-                    <option value="map.game_time">map.game_time</option>
-                    <option value="map.clock_time">map.clock_time</option>
-                    <option value="map.daytime">map.daytime</option>
-                    <option value="map.nightstalker_night">map.nightstalker_night</option>
-                    <option value="map.radiant_score">map.radiant_score</option>
-                    <option value="map.dire_score">map.dire_score</option>
-                    <option value="map.game_state">map.game_state</option>
-                    <option value="map.paused">map.paused</option>
-                    <option value="map.win_team">map.win_team</option>
-                    <option value="map.customgamename">map.customgamename</option>
-                    <option value="map.ward_purchase_cooldown">map.ward_purchase_cooldown</option>
-                  </optgroup>
                   <optgroup label="Player">
-                    <option value="player.steamid">player.steamid</option>
-                    <option value="player.accountid">player.accountid</option>
-                    <option value="player.name">player.name</option>
-                    <option value="player.activity">player.activity</option>
-                    <option value="player.kills">player.kills</option>
-                    <option value="player.deaths">player.deaths</option>
-                    <option value="player.assists">player.assists</option>
-                    <option value="player.last_hits">player.last_hits</option>
-                    <option value="player.denies">player.denies</option>
-                    <option value="player.kill_streak">player.kill_streak</option>
-                    <option value="player.commands_issued">player.commands_issued</option>
-                    <option value="player.team_name">player.team_name</option>
-                    <option value="player.player_slot">player.player_slot</option>
-                    <option value="player.team_slot">player.team_slot</option>
-                    <option value="player.gold">player.gold</option>
-                    <option value="player.gold_reliable">player.gold_reliable</option>
-                    <option value="player.gold_unreliable">player.gold_unreliable</option>
-                    <option value="player.gold_from_hero_kills">player.gold_from_hero_kills</option>
-                    <option value="player.gold_from_creep_kills">player.gold_from_creep_kills</option>
-                    <option value="player.gold_from_income">player.gold_from_income</option>
-                    <option value="player.gold_from_shared">player.gold_from_shared</option>
-                    <option value="player.gpm">player.gpm</option>
-                    <option value="player.xpm">player.xpm</option>
+                    <option value="player.kills">kills</option>
+                    <option value="player.deaths">deaths</option>
+                    <option value="player.assists">assists</option>
+                    <option value="player.last_hits">last_hits</option>
+                    <option value="player.denies">denies</option>
+                    <option value="player.kill_streak">kill_streak</option>
+                    <option value="player.gold">gold</option>
+                    <option value="player.gold_from_hero_kills">gold_from_hero_kills</option>
+                    <option value="player.gold_from_creep_kills">gold_from_creep_kills</option>
                   </optgroup>
-                  <optgroup label="Hero">
-                    <option value="hero.facet">hero.facet</option>
-                    <option value="hero.xpos">hero.xpos</option>
-                    <option value="hero.ypos">hero.ypos</option>
-                    <option value="hero.id">hero.id</option>
-                    <option value="hero.name">hero.name</option>
-                    <option value="hero.level">hero.level</option>
-                    <option value="hero.xp">hero.xp</option>
-                    <option value="hero.alive">hero.alive</option>
-                    <option value="hero.respawn_seconds">hero.respawn_seconds</option>
-                    <option value="hero.buyback_cost">hero.buyback_cost</option>
-                    <option value="hero.buyback_cooldown">hero.buyback_cooldown</option>
-                    <option value="hero.health">hero.health</option>
-                    <option value="hero.max_health">hero.max_health</option>
-                    <option value="hero.health_percent">hero.health_percent</option>
-                    <option value="hero.mana">hero.mana</option>
-                    <option value="hero.max_mana">hero.max_mana</option>
-                    <option value="hero.mana_percent">hero.mana_percent</option>
-                    <option value="hero.silenced">hero.silenced</option>
-                    <option value="hero.stunned">hero.stunned</option>
-                    <option value="hero.disarmed">hero.disarmed</option>
-                    <option value="hero.magicimmune">hero.magicimmune</option>
-                    <option value="hero.hexed">hero.hexed</option>
-                    <option value="hero.muted">hero.muted</option>
-                    <option value="hero.break">hero.break</option>
-                    <option value="hero.aghanims_scepter">hero.aghanims_scepter</option>
-                    <option value="hero.aghanims_shard">hero.aghanims_shard</option>
-                    <option value="hero.smoked">hero.smoked</option>
-                    <option value="hero.has_debuff">hero.has_debuff</option>
-                    <option value="hero.talent_1">hero.talent_1</option>
-                    <option value="hero.talent_2">hero.talent_2</option>
-                    <option value="hero.talent_3">hero.talent_3</option>
-                    <option value="hero.talent_4">hero.talent_4</option>
-                    <option value="hero.talent_5">hero.talent_5</option>
-                    <option value="hero.talent_6">hero.talent_6</option>
-                    <option value="hero.talent_7">hero.talent_7</option>
-                    <option value="hero.talent_8">hero.talent_8</option>
-                    <option value="hero.attributes_level">hero.attributes_level</option>
-                  </optgroup>
-                  <optgroup label="Abilities">
-                    <option value="abilities.ability0.name">abilities.ability0.name</option>
-                    <option value="abilities.ability0.level">abilities.ability0.level</option>
-                    <option value="abilities.ability0.can_cast">abilities.ability0.can_cast</option>
-                    <option value="abilities.ability0.passive">abilities.ability0.passive</option>
-                    <option value="abilities.ability0.ability_active">abilities.ability0.ability_active</option>
-                    <option value="abilities.ability0.cooldown">abilities.ability0.cooldown</option>
-                    <option value="abilities.ability0.max_cooldown">abilities.ability0.max_cooldown</option>
-                    <option value="abilities.ability0.ultimate">abilities.ability0.ultimate</option>
-                    <option value="abilities.ability1.name">abilities.ability1.name</option>
-                    <option value="abilities.ability1.level">abilities.ability1.level</option>
-                    <option value="abilities.ability1.can_cast">abilities.ability1.can_cast</option>
-                    <option value="abilities.ability1.passive">abilities.ability1.passive</option>
-                    <option value="abilities.ability1.ability_active">abilities.ability1.ability_active</option>
-                    <option value="abilities.ability1.cooldown">abilities.ability1.cooldown</option>
-                    <option value="abilities.ability1.max_cooldown">abilities.ability1.max_cooldown</option>
-                    <option value="abilities.ability1.ultimate">abilities.ability1.ultimate</option>
-                    <option value="abilities.ability2.name">abilities.ability2.name</option>
-                    <option value="abilities.ability2.level">abilities.ability2.level</option>
-                    <option value="abilities.ability2.can_cast">abilities.ability2.can_cast</option>
-                    <option value="abilities.ability2.passive">abilities.ability2.passive</option>
-                    <option value="abilities.ability2.ability_active">abilities.ability2.ability_active</option>
-                    <option value="abilities.ability2.cooldown">abilities.ability2.cooldown</option>
-                    <option value="abilities.ability2.max_cooldown">abilities.ability2.max_cooldown</option>
-                    <option value="abilities.ability2.ultimate">abilities.ability2.ultimate</option>
-                    <option value="abilities.ability3.name">abilities.ability3.name</option>
-                    <option value="abilities.ability3.level">abilities.ability3.level</option>
-                    <option value="abilities.ability3.can_cast">abilities.ability3.can_cast</option>
-                    <option value="abilities.ability3.passive">abilities.ability3.passive</option>
-                    <option value="abilities.ability3.ability_active">abilities.ability3.ability_active</option>
-                    <option value="abilities.ability3.cooldown">abilities.ability3.cooldown</option>
-                    <option value="abilities.ability3.max_cooldown">abilities.ability3.max_cooldown</option>
-                    <option value="abilities.ability3.ultimate">abilities.ability3.ultimate</option>
-                  </optgroup>
-                  <optgroup label="Items">
-                    <option value="items.slot0.name">items.slot0.name</option>
-                    <option value="items.slot1.name">items.slot1.name</option>
-                    <option value="items.slot2.name">items.slot2.name</option>
-                    <option value="items.slot3.name">items.slot3.name</option>
-                    <option value="items.slot4.name">items.slot4.name</option>
-                    <option value="items.slot5.name">items.slot5.name</option>
-                    <option value="items.slot6.name">items.slot6.name</option>
-                    <option value="items.slot7.name">items.slot7.name</option>
-                    <option value="items.slot8.name">items.slot8.name</option>
-                    <option value="items.teleport0.name">items.teleport0.name</option>
-                    <option value="items.neutral0.name">items.neutral0.name</option>
-                  </optgroup>
-                  <optgroup label="Buildings">
-                    <option value="buildings.dire">buildings.dire</option>
+                  <optgroup label="Map">
+                    <option value="map.win_team">win_team</option>
+                    <option value="map.clock_time">clock_time</option>
                   </optgroup>
                 </select>
               </div>
@@ -668,13 +586,11 @@
           </div>
         </div>
 
-        <div class="card">
-          <div class="card-header">
-            <h3>Mappings</h3>
-            <button class="btn-primary" onclick="saveAll()">Save Changes</button>
-          </div>
-          <div id="list"></div>
+        <div class="mappings-header">
+          <h3>Mappings</h3>
+          <button class="btn-primary" onclick="saveAll()">Save Changes</button>
         </div>
+        <div id="list"></div>
       </div>
     </div>
 
@@ -741,7 +657,7 @@
 
       function renderSoundOptions() {
         const selects = [document.getElementById('newSound')];
-        document.querySelectorAll('.mapping-item .field:first-child + .field select').forEach(s => {
+        document.querySelectorAll('.mapping-item .field:first-child select').forEach(s => {
           if (s.id !== 'newSound') selects.push(s);
         });
 
@@ -812,8 +728,8 @@
         }
       }
 
-      let mappings = [];
-      let originalMappings = [];
+      let mappings = { dota: {} };
+      let originalMappings = { dota: {} };
 
       async function load() {
         const res = await fetch('/api/mappings');
@@ -828,7 +744,7 @@
       }
 
       function hasBrokenMappings() {
-        return mappings.some(m => !sounds.includes(m.sound));
+        return Object.values(mappings.dota).flat().some(m => !sounds.includes(m.sound));
       }
 
       function updateSaveButton() {
@@ -842,207 +758,85 @@
 
       function render() {
         const list = document.getElementById('list');
-        if (mappings.length === 0) {
+        const events = Object.keys(mappings.dota);
+        if (events.length === 0) {
           list.innerHTML = '<div class="empty">No mappings yet. Add one above.</div>';
           return;
         }
-        list.innerHTML = mappings
-          .map(
-            (m, i) => {
-              const broken = isSoundBroken(m.sound);
-              const num = i + 1;
-              return `
-        <div class="mapping-item ${broken ? 'broken' : ''}">
-          <div class="order-btns">
-            <button class="btn-icon" onclick="move(${i}, -1)" ${i === 0 ? 'disabled' : ''}>▲</button>
-            <button class="btn-icon" onclick="move(${i}, 1)" ${i === mappings.length - 1 ? 'disabled' : ''}>▼</button>
+        list.innerHTML = events
+          .map((event) => {
+            const entries = mappings.dota[event];
+            return `
+        <div class="event-group">
+          <div class="event-group-header">
+            <span class="event-name">${event}</span>
+            <span class="event-count">${entries.length}</span>
           </div>
-
-          <div class="mapping-row">
-            <div class="field">
-              <label>Event Name</label>
-              <select onchange="update(${i}, 'event', this.value)">
-                <optgroup label="Map">
-                  <option value="map.name" ${m.event === 'map.name' ? 'selected' : ''}>map.name</option>
-                  <option value="map.matchid" ${m.event === 'map.matchid' ? 'selected' : ''}>map.matchid</option>
-                  <option value="map.game_time" ${m.event === 'map.game_time' ? 'selected' : ''}>map.game_time</option>
-                  <option value="map.clock_time" ${m.event === 'map.clock_time' ? 'selected' : ''}>map.clock_time</option>
-                  <option value="map.daytime" ${m.event === 'map.daytime' ? 'selected' : ''}>map.daytime</option>
-                  <option value="map.nightstalker_night" ${m.event === 'map.nightstalker_night' ? 'selected' : ''}>map.nightstalker_night</option>
-                  <option value="map.radiant_score" ${m.event === 'map.radiant_score' ? 'selected' : ''}>map.radiant_score</option>
-                  <option value="map.dire_score" ${m.event === 'map.dire_score' ? 'selected' : ''}>map.dire_score</option>
-                  <option value="map.game_state" ${m.event === 'map.game_state' ? 'selected' : ''}>map.game_state</option>
-                  <option value="map.paused" ${m.event === 'map.paused' ? 'selected' : ''}>map.paused</option>
-                  <option value="map.win_team" ${m.event === 'map.win_team' ? 'selected' : ''}>map.win_team</option>
-                  <option value="map.customgamename" ${m.event === 'map.customgamename' ? 'selected' : ''}>map.customgamename</option>
-                  <option value="map.ward_purchase_cooldown" ${m.event === 'map.ward_purchase_cooldown' ? 'selected' : ''}>map.ward_purchase_cooldown</option>
-                </optgroup>
-                <optgroup label="Player">
-                  <option value="player.steamid" ${m.event === 'player.steamid' ? 'selected' : ''}>player.steamid</option>
-                  <option value="player.accountid" ${m.event === 'player.accountid' ? 'selected' : ''}>player.accountid</option>
-                  <option value="player.name" ${m.event === 'player.name' ? 'selected' : ''}>player.name</option>
-                  <option value="player.activity" ${m.event === 'player.activity' ? 'selected' : ''}>player.activity</option>
-                  <option value="player.kills" ${m.event === 'player.kills' ? 'selected' : ''}>player.kills</option>
-                  <option value="player.deaths" ${m.event === 'player.deaths' ? 'selected' : ''}>player.deaths</option>
-                  <option value="player.assists" ${m.event === 'player.assists' ? 'selected' : ''}>player.assists</option>
-                  <option value="player.last_hits" ${m.event === 'player.last_hits' ? 'selected' : ''}>player.last_hits</option>
-                  <option value="player.denies" ${m.event === 'player.denies' ? 'selected' : ''}>player.denies</option>
-                  <option value="player.kill_streak" ${m.event === 'player.kill_streak' ? 'selected' : ''}>player.kill_streak</option>
-                  <option value="player.commands_issued" ${m.event === 'player.commands_issued' ? 'selected' : ''}>player.commands_issued</option>
-                  <option value="player.team_name" ${m.event === 'player.team_name' ? 'selected' : ''}>player.team_name</option>
-                  <option value="player.player_slot" ${m.event === 'player.player_slot' ? 'selected' : ''}>player.player_slot</option>
-                  <option value="player.team_slot" ${m.event === 'player.team_slot' ? 'selected' : ''}>player.team_slot</option>
-                  <option value="player.gold" ${m.event === 'player.gold' ? 'selected' : ''}>player.gold</option>
-                  <option value="player.gold_reliable" ${m.event === 'player.gold_reliable' ? 'selected' : ''}>player.gold_reliable</option>
-                  <option value="player.gold_unreliable" ${m.event === 'player.gold_unreliable' ? 'selected' : ''}>player.gold_unreliable</option>
-                  <option value="player.gold_from_hero_kills" ${m.event === 'player.gold_from_hero_kills' ? 'selected' : ''}>player.gold_from_hero_kills</option>
-                  <option value="player.gold_from_creep_kills" ${m.event === 'player.gold_from_creep_kills' ? 'selected' : ''}>player.gold_from_creep_kills</option>
-                  <option value="player.gold_from_income" ${m.event === 'player.gold_from_income' ? 'selected' : ''}>player.gold_from_income</option>
-                  <option value="player.gold_from_shared" ${m.event === 'player.gold_from_shared' ? 'selected' : ''}>player.gold_from_shared</option>
-                  <option value="player.gpm" ${m.event === 'player.gpm' ? 'selected' : ''}>player.gpm</option>
-                  <option value="player.xpm" ${m.event === 'player.xpm' ? 'selected' : ''}>player.xpm</option>
-                </optgroup>
-                <optgroup label="Hero">
-                  <option value="hero.facet" ${m.event === 'hero.facet' ? 'selected' : ''}>hero.facet</option>
-                  <option value="hero.xpos" ${m.event === 'hero.xpos' ? 'selected' : ''}>hero.xpos</option>
-                  <option value="hero.ypos" ${m.event === 'hero.ypos' ? 'selected' : ''}>hero.ypos</option>
-                  <option value="hero.id" ${m.event === 'hero.id' ? 'selected' : ''}>hero.id</option>
-                  <option value="hero.name" ${m.event === 'hero.name' ? 'selected' : ''}>hero.name</option>
-                  <option value="hero.level" ${m.event === 'hero.level' ? 'selected' : ''}>hero.level</option>
-                  <option value="hero.xp" ${m.event === 'hero.xp' ? 'selected' : ''}>hero.xp</option>
-                  <option value="hero.alive" ${m.event === 'hero.alive' ? 'selected' : ''}>hero.alive</option>
-                  <option value="hero.respawn_seconds" ${m.event === 'hero.respawn_seconds' ? 'selected' : ''}>hero.respawn_seconds</option>
-                  <option value="hero.buyback_cost" ${m.event === 'hero.buyback_cost' ? 'selected' : ''}>hero.buyback_cost</option>
-                  <option value="hero.buyback_cooldown" ${m.event === 'hero.buyback_cooldown' ? 'selected' : ''}>hero.buyback_cooldown</option>
-                  <option value="hero.health" ${m.event === 'hero.health' ? 'selected' : ''}>hero.health</option>
-                  <option value="hero.max_health" ${m.event === 'hero.max_health' ? 'selected' : ''}>hero.max_health</option>
-                  <option value="hero.health_percent" ${m.event === 'hero.health_percent' ? 'selected' : ''}>hero.health_percent</option>
-                  <option value="hero.mana" ${m.event === 'hero.mana' ? 'selected' : ''}>hero.mana</option>
-                  <option value="hero.max_mana" ${m.event === 'hero.max_mana' ? 'selected' : ''}>hero.max_mana</option>
-                  <option value="hero.mana_percent" ${m.event === 'hero.mana_percent' ? 'selected' : ''}>hero.mana_percent</option>
-                  <option value="hero.silenced" ${m.event === 'hero.silenced' ? 'selected' : ''}>hero.silenced</option>
-                  <option value="hero.stunned" ${m.event === 'hero.stunned' ? 'selected' : ''}>hero.stunned</option>
-                  <option value="hero.disarmed" ${m.event === 'hero.disarmed' ? 'selected' : ''}>hero.disarmed</option>
-                  <option value="hero.magicimmune" ${m.event === 'hero.magicimmune' ? 'selected' : ''}>hero.magicimmune</option>
-                  <option value="hero.hexed" ${m.event === 'hero.hexed' ? 'selected' : ''}>hero.hexed</option>
-                  <option value="hero.muted" ${m.event === 'hero.muted' ? 'selected' : ''}>hero.muted</option>
-                  <option value="hero.break" ${m.event === 'hero.break' ? 'selected' : ''}>hero.break</option>
-                  <option value="hero.aghanims_scepter" ${m.event === 'hero.aghanims_scepter' ? 'selected' : ''}>hero.aghanims_scepter</option>
-                  <option value="hero.aghanims_shard" ${m.event === 'hero.aghanims_shard' ? 'selected' : ''}>hero.aghanims_shard</option>
-                  <option value="hero.smoked" ${m.event === 'hero.smoked' ? 'selected' : ''}>hero.smoked</option>
-                  <option value="hero.has_debuff" ${m.event === 'hero.has_debuff' ? 'selected' : ''}>hero.has_debuff</option>
-                  <option value="hero.talent_1" ${m.event === 'hero.talent_1' ? 'selected' : ''}>hero.talent_1</option>
-                  <option value="hero.talent_2" ${m.event === 'hero.talent_2' ? 'selected' : ''}>hero.talent_2</option>
-                  <option value="hero.talent_3" ${m.event === 'hero.talent_3' ? 'selected' : ''}>hero.talent_3</option>
-                  <option value="hero.talent_4" ${m.event === 'hero.talent_4' ? 'selected' : ''}>hero.talent_4</option>
-                  <option value="hero.talent_5" ${m.event === 'hero.talent_5' ? 'selected' : ''}>hero.talent_5</option>
-                  <option value="hero.talent_6" ${m.event === 'hero.talent_6' ? 'selected' : ''}>hero.talent_6</option>
-                  <option value="hero.talent_7" ${m.event === 'hero.talent_7' ? 'selected' : ''}>hero.talent_7</option>
-                  <option value="hero.talent_8" ${m.event === 'hero.talent_8' ? 'selected' : ''}>hero.talent_8</option>
-                  <option value="hero.attributes_level" ${m.event === 'hero.attributes_level' ? 'selected' : ''}>hero.attributes_level</option>
-                </optgroup>
-                <optgroup label="Abilities">
-                  <option value="abilities.ability0.name" ${m.event === 'abilities.ability0.name' ? 'selected' : ''}>abilities.ability0.name</option>
-                  <option value="abilities.ability0.level" ${m.event === 'abilities.ability0.level' ? 'selected' : ''}>abilities.ability0.level</option>
-                  <option value="abilities.ability0.can_cast" ${m.event === 'abilities.ability0.can_cast' ? 'selected' : ''}>abilities.ability0.can_cast</option>
-                  <option value="abilities.ability0.passive" ${m.event === 'abilities.ability0.passive' ? 'selected' : ''}>abilities.ability0.passive</option>
-                  <option value="abilities.ability0.ability_active" ${m.event === 'abilities.ability0.ability_active' ? 'selected' : ''}>abilities.ability0.ability_active</option>
-                  <option value="abilities.ability0.cooldown" ${m.event === 'abilities.ability0.cooldown' ? 'selected' : ''}>abilities.ability0.cooldown</option>
-                  <option value="abilities.ability0.max_cooldown" ${m.event === 'abilities.ability0.max_cooldown' ? 'selected' : ''}>abilities.ability0.max_cooldown</option>
-                  <option value="abilities.ability0.ultimate" ${m.event === 'abilities.ability0.ultimate' ? 'selected' : ''}>abilities.ability0.ultimate</option>
-                  <option value="abilities.ability1.name" ${m.event === 'abilities.ability1.name' ? 'selected' : ''}>abilities.ability1.name</option>
-                  <option value="abilities.ability1.level" ${m.event === 'abilities.ability1.level' ? 'selected' : ''}>abilities.ability1.level</option>
-                  <option value="abilities.ability1.can_cast" ${m.event === 'abilities.ability1.can_cast' ? 'selected' : ''}>abilities.ability1.can_cast</option>
-                  <option value="abilities.ability1.passive" ${m.event === 'abilities.ability1.passive' ? 'selected' : ''}>abilities.ability1.passive</option>
-                  <option value="abilities.ability1.ability_active" ${m.event === 'abilities.ability1.ability_active' ? 'selected' : ''}>abilities.ability1.ability_active</option>
-                  <option value="abilities.ability1.cooldown" ${m.event === 'abilities.ability1.cooldown' ? 'selected' : ''}>abilities.ability1.cooldown</option>
-                  <option value="abilities.ability1.max_cooldown" ${m.event === 'abilities.ability1.max_cooldown' ? 'selected' : ''}>abilities.ability1.max_cooldown</option>
-                  <option value="abilities.ability1.ultimate" ${m.event === 'abilities.ability1.ultimate' ? 'selected' : ''}>abilities.ability1.ultimate</option>
-                  <option value="abilities.ability2.name" ${m.event === 'abilities.ability2.name' ? 'selected' : ''}>abilities.ability2.name</option>
-                  <option value="abilities.ability2.level" ${m.event === 'abilities.ability2.level' ? 'selected' : ''}>abilities.ability2.level</option>
-                  <option value="abilities.ability2.can_cast" ${m.event === 'abilities.ability2.can_cast' ? 'selected' : ''}>abilities.ability2.can_cast</option>
-                  <option value="abilities.ability2.passive" ${m.event === 'abilities.ability2.passive' ? 'selected' : ''}>abilities.ability2.passive</option>
-                  <option value="abilities.ability2.ability_active" ${m.event === 'abilities.ability2.ability_active' ? 'selected' : ''}>abilities.ability2.ability_active</option>
-                  <option value="abilities.ability2.cooldown" ${m.event === 'abilities.ability2.cooldown' ? 'selected' : ''}>abilities.ability2.cooldown</option>
-                  <option value="abilities.ability2.max_cooldown" ${m.event === 'abilities.ability2.max_cooldown' ? 'selected' : ''}>abilities.ability2.max_cooldown</option>
-                  <option value="abilities.ability2.ultimate" ${m.event === 'abilities.ability2.ultimate' ? 'selected' : ''}>abilities.ability2.ultimate</option>
-                  <option value="abilities.ability3.name" ${m.event === 'abilities.ability3.name' ? 'selected' : ''}>abilities.ability3.name</option>
-                  <option value="abilities.ability3.level" ${m.event === 'abilities.ability3.level' ? 'selected' : ''}>abilities.ability3.level</option>
-                  <option value="abilities.ability3.can_cast" ${m.event === 'abilities.ability3.can_cast' ? 'selected' : ''}>abilities.ability3.can_cast</option>
-                  <option value="abilities.ability3.passive" ${m.event === 'abilities.ability3.passive' ? 'selected' : ''}>abilities.ability3.passive</option>
-                  <option value="abilities.ability3.ability_active" ${m.event === 'abilities.ability3.ability_active' ? 'selected' : ''}>abilities.ability3.ability_active</option>
-                  <option value="abilities.ability3.cooldown" ${m.event === 'abilities.ability3.cooldown' ? 'selected' : ''}>abilities.ability3.cooldown</option>
-                  <option value="abilities.ability3.max_cooldown" ${m.event === 'abilities.ability3.max_cooldown' ? 'selected' : ''}>abilities.ability3.max_cooldown</option>
-                  <option value="abilities.ability3.ultimate" ${m.event === 'abilities.ability3.ultimate' ? 'selected' : ''}>abilities.ability3.ultimate</option>
-                </optgroup>
-                <optgroup label="Items">
-                  <option value="items.slot0.name" ${m.event === 'items.slot0.name' ? 'selected' : ''}>items.slot0.name</option>
-                  <option value="items.slot1.name" ${m.event === 'items.slot1.name' ? 'selected' : ''}>items.slot1.name</option>
-                  <option value="items.slot2.name" ${m.event === 'items.slot2.name' ? 'selected' : ''}>items.slot2.name</option>
-                  <option value="items.slot3.name" ${m.event === 'items.slot3.name' ? 'selected' : ''}>items.slot3.name</option>
-                  <option value="items.slot4.name" ${m.event === 'items.slot4.name' ? 'selected' : ''}>items.slot4.name</option>
-                  <option value="items.slot5.name" ${m.event === 'items.slot5.name' ? 'selected' : ''}>items.slot5.name</option>
-                  <option value="items.slot6.name" ${m.event === 'items.slot6.name' ? 'selected' : ''}>items.slot6.name</option>
-                  <option value="items.slot7.name" ${m.event === 'items.slot7.name' ? 'selected' : ''}>items.slot7.name</option>
-                  <option value="items.slot8.name" ${m.event === 'items.slot8.name' ? 'selected' : ''}>items.slot8.name</option>
-                  <option value="items.teleport0.name" ${m.event === 'items.teleport0.name' ? 'selected' : ''}>items.teleport0.name</option>
-                  <option value="items.neutral0.name" ${m.event === 'items.neutral0.name' ? 'selected' : ''}>items.neutral0.name</option>
-                </optgroup>
-                <optgroup label="Buildings">
-                  <option value="buildings.dire" ${m.event === 'buildings.dire' ? 'selected' : ''}>buildings.dire</option>
-                </optgroup>
-              </select>
-            </div>
-            <div class="field">
-              <label>Sound ${broken ? '<span style="color:var(--danger)">(missing)</span>' : ''}</label>
-              <div style="display: flex; gap: 8px;">
-                <select onchange="update(${i}, 'sound', this.value)">
-                  <option value="">Select a sound...</option>
-                  ${sounds.map(s => `<option value="${s}" ${m.sound === s ? 'selected' : ''}>${s}</option>`).join('')}
-                </select>
-                <button type="button" class="btn-icon btn-play" onclick="playSound('/api/sounds/${encodeURIComponent(m.sound)}', this)" title="Play" ${!m.sound ? 'disabled' : ''}>▶</button>
+          <div class="event-group-body">
+            ${entries
+              .map((m, i) => {
+                const broken = isSoundBroken(m.sound);
+                return `
+              <div class="mapping-item ${broken ? 'broken' : ''}" data-event="${event}" data-idx="${i}">
+                <div class="order-btns">
+                  <button class="btn-icon" onclick="move('${event}', ${i}, -1)" ${i === 0 ? 'disabled' : ''}>▲</button>
+                  <button class="btn-icon" onclick="move('${event}', ${i}, 1)" ${i === entries.length - 1 ? 'disabled' : ''}>▼</button>
+                </div>
+                <div class="mapping-row">
+                  <div class="field">
+                    <label>Sound ${broken ? '<span style="color:var(--danger)">(missing)</span>' : ''}</label>
+                    <div style="display: flex; gap: 8px;">
+                      <select onchange="update('${event}', ${i}, 'sound', this.value)">
+                        <option value="">Select a sound...</option>
+                        ${sounds.map((s) => `<option value="${s}" ${m.sound === s ? 'selected' : ''}>${s}</option>`).join('')}
+                      </select>
+                      <button type="button" class="btn-icon btn-play" onclick="playSound('/api/sounds/${encodeURIComponent(m.sound)}', this)" title="Play" ${!m.sound ? 'disabled' : ''}>▶</button>
+                    </div>
+                  </div>
+                  <div class="field small">
+                    <label>Condition</label>
+                    <select onchange="update('${event}', ${i}, 'condition', this.value); updateRowValueField('${event}', ${i}, this.value)">
+                      <option value=">" ${m.condition === '>' ? 'selected' : ''}>&gt;</option>
+                      <option value="<" ${m.condition === '<' ? 'selected' : ''}>&lt;</option>
+                      <option value="===" ${m.condition === '===' || !m.condition ? 'selected' : ''}>=</option>
+                      <option value="!==" ${m.condition === '!==' ? 'selected' : ''}>!=</option>
+                      <option value="*" ${m.condition === '*' ? 'selected' : ''}>*</option>
+                      <option value="%" ${m.condition === '%' ? 'selected' : ''}>%</option>
+                    </select>
+                  </div>
+                  <div class="field tiny">
+                    <label>Value</label>
+                    <input type="text" value="${m.condition === '*' ? '' : m.value !== undefined ? m.value : ''}" ${m.condition === '*' ? 'disabled' : ''} onchange="update('${event}', ${i}, 'value', this.value)">
+                  </div>
+                  <div class="field small">
+                    <label class="checkbox-label">Suppress</label>
+                    <input type="checkbox" ${m.suppress ? 'checked' : ''} onchange="update('${event}', ${i}, 'suppress', this.checked)">
+                  </div>
+                </div>
+                <div class="mapping-actions">
+                  <button class="btn-icon danger" onclick="remove('${event}', ${i})">✕</button>
+                </div>
               </div>
-            </div>
-            <div class="field small">
-              <label>Condition</label>
-              <select onchange="update(${i}, 'condition', this.value); updateRowValueField(${i}, this.value)">
-                <option value=">" ${m.condition === '>' ? 'selected' : ''}>&gt;</option>
-                <option value="<" ${m.condition === '<' ? 'selected' : ''}>&lt;</option>
-                <option value="===" ${m.condition === '===' || !m.condition ? 'selected' : ''}>=</option>
-                <option value="!==" ${m.condition === '!==' ? 'selected' : ''}>!=</option>
-                <option value="*" ${m.condition === '*' ? 'selected' : ''}>*</option>
-                <option value="%" ${m.condition === '%' ? 'selected' : ''}>%</option>
-              </select>
-            </div>
-            <div class="field tiny">
-              <label>Value</label>
-              <input type="text" value="${m.condition === '*' ? '' : m.value !== undefined ? m.value : ''}" ${m.condition === '*' ? 'disabled' : ''} onchange="update(${i}, 'value', this.value)">
-            </div>
-            <div class="field small">
-              <label class="checkbox-label">Suppress</label>
-              <input type="checkbox" ${m.suppress ? 'checked' : ''} onchange="update(${i}, 'suppress', this.checked)">
-            </div>
-          </div>
-          <div class="mapping-actions">
-            <button class="btn-icon danger" onclick="remove(${i})">✕</button>
+              `;
+              })
+              .join('')}
           </div>
         </div>
       `;
-            },
-          )
+          })
           .join('');
         updateSaveButton();
       }
 
-      function update(idx, key, val) {
+      function update(event, idx, key, val) {
         if (key === 'value') val = parseValue(val);
-        mappings[idx][key] = val;
+        mappings.dota[event][idx][key] = val;
         render();
       }
 
-      function updateRowValueField(idx, condition) {
-        const items = document.querySelectorAll('.mapping-item');
-        const valueInput = items[idx].querySelector('.field.tiny input');
+      function updateRowValueField(event, idx, condition) {
+        const item = document.querySelector(`.mapping-item[data-event="${event}"][data-idx="${idx}"]`);
+        const valueInput = item.querySelector('.field.tiny input');
         valueInput.disabled = condition === '*';
         if (condition === '*') {
           valueInput.value = '';
@@ -1071,33 +865,26 @@
           return;
         }
 
-        mappings.unshift({ event, sound, condition, value, suppress });
+        if (!mappings.dota[event]) mappings.dota[event] = [];
+        mappings.dota[event].unshift({ sound, condition, value, suppress });
         render();
-
-        const items = document.querySelectorAll('.mapping-item');
-        items[0].classList.add('placed');
 
         clearForm();
         showMsg('Mapping added', 'success');
       }
 
-      function remove(idx) {
-        const items = document.querySelectorAll('.mapping-item');
-        items[idx].style.opacity = '0';
-        items[idx].style.transform = 'translateX(-20px) scale(0.95)';
-
-        setTimeout(() => {
-          mappings.splice(idx, 1);
-          render();
-        }, 200);
+      function remove(event, idx) {
+        mappings.dota[event].splice(idx, 1);
+        if (mappings.dota[event].length === 0) delete mappings.dota[event];
+        render();
       }
 
-      function move(idx, dir) {
-        if (idx + dir < 0 || idx + dir >= mappings.length) return;
-        const temp = mappings[idx];
-        mappings[idx] = mappings[idx + dir];
-        mappings[idx + dir] = temp;
-
+      function move(event, idx, dir) {
+        const arr = mappings.dota[event];
+        if (idx + dir < 0 || idx + dir >= arr.length) return;
+        const temp = arr[idx];
+        arr[idx] = arr[idx + dir];
+        arr[idx + dir] = temp;
         render();
       }
 

--- a/public/index.html
+++ b/public/index.html
@@ -6,10 +6,6 @@
     <title>Mapping Editor</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
     <style>
       @font-face {
         font-family: 'Reaver';
@@ -18,18 +14,19 @@
         font-style: normal;
       }
       :root {
-        --bg: #0d1117;
-        --card-bg: #161b22;
-        --input-bg: #0d1117;
-        --border: #30363d;
-        --text: #c9d1d9;
-        --text-muted: #8b949e;
-        --accent: #58a6ff;
-        --accent-hover: #79c0ff;
-        --accent-subtle: rgba(88, 166, 255, 0.1);
-        --danger: #f85149;
-        --success: #3fb950;
-        --purple: #a371f7;
+        --bg: #1d1d1d;
+        --card-bg: #242424;
+        --input-bg: #161616;
+        --border: #3a3020;
+        --text: #ffaf00;
+        --text-muted: #8a6e2f;
+        --accent: #ffaf00;
+        --accent-hover: #ffcc33;
+        --accent-subtle: rgba(255, 175, 0, 0.08);
+        --danger: #fb4934;
+        --success: #b8bb26;
+        --glow: 0 0 10px rgba(255, 175, 0, 0.3);
+        --glow-strong: 0 0 20px rgba(255, 175, 0, 0.4);
       }
       * {
         box-sizing: border-box;
@@ -38,19 +35,19 @@
         font-family: inherit;
       }
       body {
-        font-family:
-          'IBM Plex Sans',
-          -apple-system,
-          BlinkMacSystemFont,
-          'Segoe UI',
-          sans-serif;
+        font-family: 'Share Tech Mono', 'Fira Code', 'SF Mono', 'Courier New', monospace;
         background: var(--bg);
         color: var(--text);
         min-height: 100vh;
         padding: 40px 20px;
         background-image:
-          radial-gradient(ellipse at top left, rgba(88, 166, 255, 0.08) 0%, transparent 50%),
-          radial-gradient(ellipse at bottom right, rgba(163, 113, 247, 0.06) 0%, transparent 50%);
+          repeating-linear-gradient(
+            0deg,
+            rgba(255, 175, 0, 0.03) 0px,
+            rgba(255, 175, 0, 0.03) 1px,
+            transparent 1px,
+            transparent 3px
+          );
       }
       h1 {
         font-size: 48px;
@@ -61,21 +58,34 @@
         display: flex;
         align-items: center;
         gap: 14px;
+        text-shadow: var(--glow-strong);
+        position: relative;
+        z-index: 1;
       }
       h1 img {
         height: 64px;
+        filter: invert(48%) sepia(89%) saturate(2000%) hue-rotate(5deg) brightness(110%) drop-shadow(var(--glow));
+      }
+      .cursor {
+        animation: blink 1s step-end infinite;
+        font-weight: normal;
+      }
+      @keyframes blink {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0; }
       }
       .container {
         max-width: 960px;
         margin: 0 auto;
+        position: relative;
+        z-index: 1;
       }
       .card {
         background: var(--card-bg);
         border: 1px solid var(--border);
-        border-radius: 16px;
+        border-radius: 4px;
         padding: 28px;
         margin-bottom: 24px;
-        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
       }
       .card-header {
         display: flex;
@@ -95,7 +105,7 @@
         font-weight: 600;
         color: var(--text-muted);
         text-transform: uppercase;
-        letter-spacing: 1px;
+        letter-spacing: 2px;
       }
 
       .field-group {
@@ -128,11 +138,11 @@
 
       .field label {
         display: block;
-        font-size: 11px;
+        font-size: 10px;
         font-weight: 600;
         color: var(--text-muted);
         text-transform: uppercase;
-        letter-spacing: 0.5px;
+        letter-spacing: 1px;
         margin-bottom: 8px;
       }
       .field label.checkbox-label {
@@ -143,31 +153,36 @@
       input,
       select {
         width: 100%;
-        padding: 12px 14px;
-        border-radius: 10px;
+        padding: 10px 12px;
+        border-radius: 2px;
         border: 1px solid var(--border);
         background: var(--input-bg);
         color: var(--text);
-        font-size: 14px;
-        font-family: inherit;
-        transition: all 0.2s;
+        font-size: 13px;
+        font-family: 'Share Tech Mono', 'Fira Code', monospace;
+        transition: all 0.15s;
       }
       input[type="checkbox"] {
-        width: 20px;
-        height: 20px;
+        width: 18px;
+        height: 18px;
         accent-color: var(--accent);
         cursor: pointer;
         padding: 0;
+        background: var(--input-bg);
+        border: 1px solid var(--border);
+      }
+      input[type="checkbox"]:not(:checked) {
+        opacity: 0.4;
       }
       input:focus,
       select:focus {
         outline: none;
         border-color: var(--accent);
-        box-shadow: 0 0 0 4px var(--accent-subtle);
+        box-shadow: var(--glow);
       }
       input:hover,
       select:hover {
-        border-color: rgba(88, 166, 255, 0.4);
+        border-color: rgba(255, 175, 0, 0.4);
       }
       input::placeholder {
         color: var(--text-muted);
@@ -186,37 +201,42 @@
       }
       input:disabled,
       select:disabled {
-        opacity: 0.5;
+        opacity: 0.3;
         cursor: not-allowed;
       }
 
       button {
-        padding: 12px 24px;
-        border-radius: 10px;
-        border: none;
+        padding: 10px 20px;
+        border-radius: 2px;
+        border: 1px solid var(--border);
         cursor: pointer;
-        font-size: 14px;
+        font-size: 12px;
         font-weight: 600;
-        font-family: inherit;
-        transition: all 0.2s;
+        font-family: 'Share Tech Mono', monospace;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        transition: all 0.15s;
+        background: var(--input-bg);
+        color: var(--text-muted);
       }
       .btn-primary {
-        background: linear-gradient(135deg, var(--accent), #3d8bfd);
-        color: #000;
-        box-shadow: 0 4px 16px rgba(88, 166, 255, 0.3);
+        background: var(--input-bg);
+        color: var(--text);
+        border-color: var(--accent);
+        box-shadow: var(--glow);
       }
       .btn-primary:hover {
-        background: linear-gradient(135deg, var(--accent-hover), #5a9efe);
-        transform: translateY(-2px);
-        box-shadow: 0 6px 24px rgba(88, 166, 255, 0.4);
+        background: rgba(255, 175, 0, 0.1);
+        box-shadow: var(--glow-strong);
+        text-shadow: var(--glow);
       }
 
       .mapping-item:hover {
-        border-color: rgba(88, 166, 255, 0.4);
+        border-color: rgba(255, 175, 0, 0.4);
+        box-shadow: var(--glow);
       }
       .mapping-item.reorder {
-        opacity: 0.6;
-        transform: scale(0.99);
+        opacity: 0.5;
       }
       .mapping-item.placed {
         animation: highlight 0.4s ease;
@@ -244,30 +264,30 @@
         align-items: center;
       }
       .btn-icon {
-        width: 36px;
-        height: 36px;
+        width: 32px;
+        height: 32px;
         padding: 0;
         display: flex;
         align-items: center;
         justify-content: center;
-        border-radius: 8px;
-        background: var(--card-bg);
+        border-radius: 2px;
+        background: var(--input-bg);
         color: var(--text-muted);
         border: 1px solid var(--border);
-        font-size: 12px;
+        font-size: 11px;
       }
       .btn-icon:hover:not(:disabled) {
         color: var(--accent);
         border-color: var(--accent);
-        background: var(--accent-subtle);
+        box-shadow: var(--glow);
       }
       .btn-icon:disabled {
-        opacity: 0.3;
+        opacity: 0.2;
         cursor: not-allowed;
       }
 
       .btn-primary:disabled {
-        background: var(--border);
+        border-color: var(--border);
         color: var(--text-muted);
         box-shadow: none;
         cursor: not-allowed;
@@ -275,20 +295,20 @@
       }
 
       .btn-icon.danger {
-        background: rgba(248, 81, 73, 0.15);
+        background: rgba(255, 51, 51, 0.1);
         color: var(--danger);
-        border-color: transparent;
+        border-color: rgba(255, 51, 51, 0.3);
       }
       .btn-icon.danger:hover:not(:disabled) {
-        background: var(--danger);
-        color: #fff;
+        background: rgba(255, 51, 51, 0.2);
         border-color: var(--danger);
+        box-shadow: 0 0 10px rgba(255, 51, 51, 0.3);
       }
 
       .btn-play.playing {
         color: var(--success);
         border-color: var(--success);
-        background: rgba(63, 185, 80, 0.15);
+        box-shadow: var(--glow);
       }
 
       .order-btns {
@@ -302,43 +322,44 @@
         align-items: center;
         background: var(--input-bg);
         border: 1px solid var(--border);
-        border-radius: 12px;
-        padding: 20px;
-        margin-bottom: 16px;
-        transition: all 0.25s ease;
+        border-radius: 2px;
+        padding: 16px;
+        margin-bottom: 8px;
+        transition: all 0.15s ease;
         gap: 10px;
       }
 
       .event-group {
-        margin-bottom: 24px;
+        margin-bottom: 20px;
       }
       .event-group-header {
         display: flex;
         align-items: center;
         gap: 10px;
-        padding: 12px 16px;
-        background: var(--card-bg);
+        padding: 10px 14px;
+        background: var(--input-bg);
         border: 1px solid var(--border);
-        border-radius: 12px 12px 0 0;
+        border-bottom: none;
+        border-radius: 2px 2px 0 0;
       }
       .event-name {
-        font-size: 14px;
+        font-size: 13px;
         font-weight: 600;
         color: var(--accent);
-        font-family: 'SF Mono', 'Fira Code', monospace;
+        text-shadow: var(--glow);
       }
       .event-count {
-        font-size: 12px;
+        font-size: 10px;
         color: var(--text-muted);
-        background: var(--input-bg);
+        background: var(--card-bg);
         padding: 2px 8px;
-        border-radius: 6px;
+        border-radius: 2px;
+        border: 1px solid var(--border);
       }
       .event-group-body {
         border: 1px solid var(--border);
-        border-top: none;
-        border-radius: 0 0 12px 12px;
-        padding: 12px;
+        border-radius: 0 0 2px 2px;
+        padding: 8px;
         background: var(--card-bg);
       }
 
@@ -351,34 +372,39 @@
         position: fixed;
         top: 24px;
         right: 24px;
-        padding: 16px 24px;
-        border-radius: 12px;
-        font-size: 14px;
+        padding: 12px 20px;
+        border-radius: 2px;
+        font-size: 12px;
         font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 1px;
         transform: translateX(120%);
-        transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        transition: transform 0.2s ease;
         z-index: 1000;
       }
       .msg.show {
         transform: translateX(0);
       }
       .msg.success {
-        background: linear-gradient(135deg, var(--success), #2ea043);
-        color: #fff;
-        box-shadow: 0 8px 24px rgba(63, 185, 80, 0.4);
+        background: var(--input-bg);
+        color: var(--success);
+        border: 1px solid var(--success);
+        box-shadow: var(--glow);
       }
       .msg.error {
-        background: linear-gradient(135deg, var(--danger), #da3633);
-        color: #fff;
-        box-shadow: 0 8px 24px rgba(248, 81, 73, 0.4);
+        background: var(--input-bg);
+        color: var(--danger);
+        border: 1px solid var(--danger);
+        box-shadow: 0 0 10px rgba(255, 51, 51, 0.3);
       }
       @keyframes highlight {
         0% {
-          background: rgba(88, 166, 255, 0.2);
           border-color: var(--accent);
+          box-shadow: var(--glow-strong);
         }
         100% {
-          background: var(--input-bg);
+          border-color: var(--border);
+          box-shadow: none;
         }
       }
 
@@ -388,25 +414,29 @@
         margin-bottom: 24px;
       }
       .tab {
-        padding: 12px 24px;
-        border-radius: 10px;
-        background: var(--card-bg);
+        padding: 10px 20px;
+        border-radius: 2px;
+        background: var(--input-bg);
         color: var(--text-muted);
         border: 1px solid var(--border);
         cursor: pointer;
-        font-size: 14px;
+        font-size: 11px;
         font-weight: 600;
-        font-family: inherit;
-        transition: all 0.2s;
+        font-family: 'Share Tech Mono', monospace;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        transition: all 0.15s;
       }
       .tab:hover {
-        border-color: rgba(88, 166, 255, 0.4);
+        border-color: rgba(255, 175, 0, 0.4);
         color: var(--text);
       }
       .tab.active {
-        background: var(--accent);
-        color: #000;
+        background: rgba(255, 175, 0, 0.1);
+        color: var(--accent);
         border-color: var(--accent);
+        box-shadow: var(--glow);
+        text-shadow: var(--glow);
       }
 
       .tab-content {
@@ -419,42 +449,42 @@
       .sound-list {
         display: flex;
         flex-direction: column;
-        gap: 12px;
+        gap: 8px;
       }
       .sound-item {
         display: flex;
         align-items: center;
         gap: 12px;
-        padding: 12px 16px;
+        padding: 10px 14px;
         background: var(--input-bg);
         border: 1px solid var(--border);
-        border-radius: 10px;
+        border-radius: 2px;
       }
       .sound-item:hover {
-        border-color: rgba(88, 166, 255, 0.4);
+        border-color: rgba(255, 175, 0, 0.4);
       }
       .sound-name {
         flex: 1;
-        font-size: 14px;
+        font-size: 12px;
         color: var(--text);
         word-break: break-all;
       }
       .sound-actions {
         display: flex;
-        gap: 8px;
+        gap: 6px;
       }
       .upload-area {
-        padding: 32px;
-        border: 2px dashed var(--border);
-        border-radius: 12px;
+        padding: 28px;
+        border: 1px dashed var(--border);
+        border-radius: 2px;
         text-align: center;
         margin-bottom: 24px;
-        transition: all 0.2s;
+        transition: all 0.15s;
         cursor: pointer;
       }
       .upload-area:hover {
         border-color: var(--accent);
-        background: var(--accent-subtle);
+        box-shadow: var(--glow);
       }
       .upload-area input[type='file'] {
         display: none;
@@ -462,7 +492,7 @@
       .upload-label {
         cursor: pointer;
         color: var(--text-muted);
-        font-size: 14px;
+        font-size: 12px;
       }
       .upload-label:hover {
         color: var(--text);
@@ -470,7 +500,7 @@
 
       .mapping-item.broken {
         border-color: var(--danger);
-        box-shadow: 0 0 0 2px rgba(248, 81, 73, 0.2);
+        box-shadow: 0 0 10px rgba(255, 51, 51, 0.2);
       }
       .mapping-item.broken .field select {
         border-color: var(--danger);
@@ -501,6 +531,7 @@
       }
 
     </style>
+    <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
   </head>
   <body>
     <div class="container">
@@ -508,7 +539,7 @@
         <img
           src="https://cdn.steamstatic.com/apps/dota2/images/dota_react/global/dota2_logo_symbol.png"
           alt=""
-        />OBSERVER WARD
+        />OBSERVER WARD<span class="cursor">_</span>
       </h1>
       <div id="msg" class="msg"></div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -101,9 +101,9 @@
         margin-top: 24px;
       }
       h3 {
-        font-size: 13px;
+        font-size: 16px;
         font-weight: 600;
-        color: var(--text-muted);
+        color: var(--accent);
         text-transform: uppercase;
         letter-spacing: 2px;
       }
@@ -138,7 +138,7 @@
 
       .field label {
         display: block;
-        font-size: 10px;
+        font-size: 12px;
         font-weight: 600;
         color: var(--text-muted);
         text-transform: uppercase;
@@ -343,7 +343,7 @@
         border-radius: 2px 2px 0 0;
       }
       .event-name {
-        font-size: 13px;
+        font-size: 14px;
         font-weight: 600;
         color: var(--accent);
         text-shadow: var(--glow);

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ import { logEvent, logRawRequest } from './clickhouse.js';
 import { connections } from './discord.js';
 import logger from './logger.js';
 import { httpRequestsTotal, httpRequestDuration, gameEventsTotal, soundsPlayedTotal } from './metrics.js';
-import type { GameEvent, GameEventContext, MappingEntry, Settings } from './types.js';
+import type { GameEvent, GameEventContext, MappingConfig, MappingEntry, Settings } from './types.js';
 
 const tracer = trace.getTracer('discord-dota', '1.0.0');
 
@@ -197,14 +197,11 @@ const handleGameEvent = async (event: GameEvent): Promise<void> =>
 
       let matchedIndex = -1;
       tracer.startActiveSpan('game.event.mapping.evaluate', (mappingSpan) => {
-        mappingSpan.setAttribute('mapping.entries_count', mapping.length);
+        mappingSpan.setAttribute('mapping.entries_count', Object.values(mapping.dota).flat().length);
         mappingSpan.setAttribute('event.name', event.name);
         try {
-          for (const [idx, obj] of mapping.entries()) {
-            if (obj.event !== event.name) {
-              continue;
-            }
-
+          const entries = mapping.dota[event.name] ?? [];
+          for (const [idx, obj] of entries.entries()) {
             let play = false;
             switch (obj.condition) {
               case '*': {
@@ -295,13 +292,13 @@ const handleGameEvent = async (event: GameEvent): Promise<void> =>
 
 const configFile = 'mapping.json';
 const config = Bun.file(configFile);
-let mapping: MappingEntry[] = [];
+let mapping: MappingConfig = { dota: {} };
 
 if (await config.exists()) {
   mapping = await config.json();
 } else {
-  await Bun.write(configFile, '[]');
-  mapping = [];
+  await Bun.write(configFile, JSON.stringify({ dota: {} }, null, 2));
+  mapping = { dota: {} };
 }
 let suppressReport = false;
 
@@ -355,10 +352,15 @@ app.get('/api/mappings', async (c) =>
 app.put('/api/mappings', async (c) =>
   tracer.startActiveSpan('api.mappings.write', async (span) => {
     try {
-      const data = (await c.req.json()) as MappingEntry[];
+      const data = (await c.req.json()) as MappingConfig;
+      const sorted = Object.keys(data.dota).toSorted().reduce((acc, key) => {
+        acc[key] = data.dota[key]!;
+        return acc;
+      }, {} as Record<string, MappingEntry[]>);
+      data.dota = sorted;
       await Bun.write('mapping.json', JSON.stringify(data, null, 2));
       mapping = data;
-      span.setAttribute('mappings.count', data.length);
+      span.setAttribute('mappings.count', Object.values(data.dota).flat().length);
       return c.json({ success: true });
     } catch (error) {
       span.setStatus({ code: SpanStatusCode.ERROR });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,14 @@
 import type { Client, Collection, ChatInputCommandInteraction } from 'discord.js';
 
 export interface MappingEntry {
-  event: string;
   sound: string;
   condition: '*' | '>' | '<' | '===' | '!==' | '%';
   value: number | string;
   suppress?: boolean;
+}
+
+export interface MappingConfig {
+  dota: Record<string, MappingEntry[]>;
 }
 
 export interface GameEvent {


### PR DESCRIPTION
## Summary
- Restructure `mapping.json` from flat array to nested `{ "dota": { "event.name": [...] } }` format
- Backend now does direct event lookup instead of iterating all mappings
- Frontend groups mappings by event name instead of a flat list
- Keys are sorted alphabetically on save
- Restyled web UI with gruvbox-amber theme and monospace fonts

## Changes
- **`src/types.ts`** — Removed `event` from `MappingEntry`, added `MappingConfig`
- **`src/server.ts`** — Uses `MappingConfig` type, direct `mapping.dota[event.name]` lookup, alphabetically sorts keys on write
- **`public/index.html`** — Grouped event UI, amber/terminal theme, blinking cursor on title
- **`mapping.json`** — Rewritten to nested format
- **`README.md`**, **`AGENTS.md`** — Updated docs